### PR TITLE
Tweak packer to remove jumpcloud config files when building the ecs ami

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install-tools: $(tools)
 	install -S -m 0755 $< /usr/local/bin
 
 amis:
-	pack-ami build -p ./packer -t base -r
+	PACKER_LOG=1 pack-ami build -p ./packer -t base -r
 
 plan-ami:
 	pack-ami plan -p ./packer -t ${template}

--- a/packer/base/scripts/jumpcloud.sh
+++ b/packer/base/scripts/jumpcloud.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 set -e
 
-curl --silent --show-error --header 'x-connect-key: 742502a44e0afaace6bfd914f824fd2d9d7a10cd' https://kickstart.jumpcloud.com/Kickstart | bash
+curl --silent --show-error --header 'x-connect-key: 742502a44e0afaace6bfd914f824fd2d9d7a10cd' https://kickstart.jumpcloud.com/Kickstart | sudo bash
+sleep 5
+sudo service jcagent stop
+sleep 5
+sudo rm -f /opt/jc/ca.crt /opt/jc/client.crt /opt/jc/client.key /opt/jc/jcagent.conf

--- a/packer/ecs/packer.yml
+++ b/packer/ecs/packer.yml
@@ -3,3 +3,4 @@ base: base
 
 scripts:
   - ecs.sh
+  - jumpcloud.sh

--- a/packer/ecs/scripts/jumpcloud.sh
+++ b/packer/ecs/scripts/jumpcloud.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+sudo service jcagent stop
+sleep 5
+sudo rm -f /opt/jc/ca.crt /opt/jc/client.crt /opt/jc/client.key /opt/jc/jcagent.conf


### PR DESCRIPTION
Packer builds 2 AMIs one is the base AMI and the second is the ECS AMI. When the ECS AMI is built the jumpcloud agent will contact jumpcloud and register the "instance" we need to remove the configuration files in this step as well as the base step so instances created with this AMI will not share the same system identifier.

https://support.jumpcloud.com/customer/en/portal/articles/2399081